### PR TITLE
LavalandWeaponKinetic on back and suitstorage

### DIFF
--- a/Resources/Prototypes/_Lavaland/Entities/Objects/Weapons/crushers.yml
+++ b/Resources/Prototypes/_Lavaland/Entities/Objects/Weapons/crushers.yml
@@ -114,7 +114,7 @@
       types:
         Blunt: 11
         Slash: 9
-  - type: Clothing
+  - type: Clothing # Corvax-Goob-Krushers-on-back
     sprite: Objects/Weapons/Melee/crusher.rsi
     quickEquip: false
     slots:
@@ -158,7 +158,7 @@
     boost:
       types: # BLOOD FOR THE BLOOD GOD ITS A FUCKING HAMMER
         Blunt: 75
-  - type: Clothing
+  - type: Clothing # Corvax-Goob-Krushers-on-back
     sprite: Objects/Weapons/Melee/crusher.rsi
     quickEquip: false
     slots:
@@ -246,7 +246,7 @@
   - type: BlockCharge
     rechargeTime: 120
     markerReductionTime: 20
-  - type: Clothing
+  - type: Clothing # Corvax-Goob-Krushers-on-back
     sprite: Objects/Weapons/Melee/crusher.rsi
     quickEquip: false
     slots:

--- a/Resources/Prototypes/_Lavaland/Entities/Objects/Weapons/crushers.yml
+++ b/Resources/Prototypes/_Lavaland/Entities/Objects/Weapons/crushers.yml
@@ -114,6 +114,12 @@
       types:
         Blunt: 11
         Slash: 9
+  - type: Clothing
+    sprite: Objects/Weapons/Melee/crusher.rsi
+    quickEquip: false
+    slots:
+    - Back
+    - suitStorage
 
 - type: entity
   parent: LavalandWeaponKineticBase
@@ -152,6 +158,12 @@
     boost:
       types: # BLOOD FOR THE BLOOD GOD ITS A FUCKING HAMMER
         Blunt: 75
+  - type: Clothing
+    sprite: Objects/Weapons/Melee/crusher.rsi
+    quickEquip: false
+    slots:
+    - Back
+    - suitStorage
 
 
 - type: entity
@@ -234,3 +246,9 @@
   - type: BlockCharge
     rechargeTime: 120
     markerReductionTime: 20
+  - type: Clothing
+    sprite: Objects/Weapons/Melee/crusher.rsi
+    quickEquip: false
+    slots:
+    - Back
+    - suitStorage


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
## Описание PR
<!-- Что вы изменили? -->
Кинетическое копьё, кинетический молот и кинетическое мачете теперь можно носить в слотах для сумок и баллонов.

## Почему / Баланс
<!-- Обсудите, как это повлияет на баланс игры или объясните, почему это было изменено. Укажите ссылки на соответствующие обсуждения или issue. -->
https://discord.com/channels/919301044784226385/1394992436916260964 а вообще реально удобно и полезно.

## Медиа
<!-- Прикрепите медиафайлы, если PR вносит изменения в игру (одежда, предметы, механики и т.д.).
Небольшие исправления/рефакторинг освобождаются от этого требования. -->
(их нету, спрайты для них на спину отдельные в будущем нарисую)

**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
Убедитесь, что вы прочитали рекомендации и вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. -->
<!--
:cl:
- add: Добавлена возможность положить кинетическое оружие лаваленда в слоты для рюкзака и баллонов.
-->
:cl:
- add: Добавлена возможность положить кинетическое оружие лаваленда в слоты для рюкзака и баллонов.