### PR TITLE
Auto emotes on damage

### DIFF
--- a/Content.Server/Chat/EmoteOnDamageComponent.cs
+++ b/Content.Server/Chat/EmoteOnDamageComponent.cs
@@ -10,7 +10,6 @@ namespace Content.Server.Chat;
 using Content.Server.Chat.Systems;
 using Content.Shared.Chat.Prototypes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
-using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.Set;
 
 /// <summary>
 /// Causes an entity to automatically emote when taking damage.
@@ -25,11 +24,11 @@ public sealed partial class EmoteOnDamageComponent : Component
     public float EmoteChance = 0.5f;
 
     /// <summary>
-    /// A set of emotes that will be randomly picked from.
+    /// A dictionary of emotes threshold that will be randomly picked from.
     /// <see cref="EmotePrototype"/>
     /// </summary>
-    [DataField("emotes", customTypeSerializer: typeof(PrototypeIdHashSetSerializer<EmotePrototype>)), ViewVariables(VVAccess.ReadWrite)]
-    public HashSet<string> Emotes = new();
+    [DataField("emotes"), ViewVariables(VVAccess.ReadWrite)]
+    public Dictionary<float, HashSet<string>> EmotesThreshold = new(); // CorvaxGoob-AutoEmote : Changes
 
     /// <summary>
     /// Also send the emote in chat.
@@ -56,4 +55,12 @@ public sealed partial class EmoteOnDamageComponent : Component
     /// </summary>
     [DataField("emoteCooldown"), ViewVariables(VVAccess.ReadWrite)]
     public TimeSpan EmoteCooldown = TimeSpan.FromSeconds(2);
+
+    // CorvaxGoob-AutoEmote-Start : Changes
+    [DataField]
+    public HashSet<string> AllowedDamageType = ["Blunt", "Caustic", "Heat", "Cold", "Piercing", "Shock", "Slash"];
+
+    [DataField]
+    public float PainThreshold = 6.0f;
+    // CorvaxGoob-AutoEmote-End : Changes
 }

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -482,6 +482,15 @@
     - DoorBumpOpener
     - AnomalyHost
   - type: LayingDown # WD EDIT
+  - type: EmoteOnDamage # CorvaxGoob-AutoEmote
+    emotes:
+      20: ["Scream"] # >80 of alive HP. Scream only
+      60: ["Scream", "Crying"] # Precrit. Crying and scream
+    emoteChance: 0.6
+    withChat: true
+    hiddenFromChatWindow: true
+    emoteCooldown: 8
+
   - type: Targeting # Shitmed Change
   - type: CanEscapeInventory # GoobStation - Escape being picked up by players
   - type: Consciousness


### PR DESCRIPTION
## Описание PR
Добавлены эмоуты при получении урона болевого порога. Куклы с трейтом "Невосприимчивость к боли" игнорируют данный эффект.

## Почему / Баланс
Крик был убран из меню действий, эта фича станет её альтернативой. Получая достаточно болезненный урон, человечушка начинает вопить

## Технические детали
При получении урона, привышающий болевой порог (6 единиц либо холода, брута, бланта, и т.п, кроме ядов, радиации, кровотечения и удушения) выбирается эмоут из `EmotesThreshold` в соответствием с его текущим состоянием здоровья с кулдауном в 8 секунд с момента последнего эмоута. `PainNumbnessComponent` отключает эту систему

Словарь состояния здоровья и эмоций:

```
20: ["Scream"]. больше 20 урона в кукле. Крик
60: ["Scream", "Crying"] больше 60 урона в кукле. Крик и плач
```

## Медиа

https://github.com/user-attachments/assets/21b40a0a-8229-40d8-84d6-26f8dadf8845


## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
<!-- Вы должны понимать, что несоблюдение вышеуказанного может привести к закрытию вашего PR по усмотрению сопровождающего -->

**Список изменений**

:cl: KillanGenifer
- add: Добавлена система автоэмоций при получении значительных повреждений.