### PR TITLE
Ores rebalance

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Materials/ore.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/ore.yml
@@ -79,7 +79,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      RawGold: 500 # Goobstation - was 100
+      RawGold: 200 # Goobstation - was 100 # Corvax-Goob-OreSmeltingRebalance
   - type: Extractable
     grindableSolutionName: goldore
   - type: SolutionContainerManager
@@ -159,7 +159,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      RawIron: 300 # Goobstation - was 100
+      RawIron: 200 # Goobstation - was 100 # Corvax-Goob-OreSmeltingRebalance
   - type: Extractable
     grindableSolutionName: ironore
   - type: SolutionContainerManager
@@ -197,7 +197,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      RawPlasma: 500 # Goobstation - was 100
+      RawPlasma: 200 # Goobstation - was 100 # Corvax-Goob-OreSmeltingRebalance
   - type: PointLight
     radius: 1.2
     energy: 0.6
@@ -244,7 +244,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      RawSilver: 500 # Goobstation - was 100
+      RawSilver: 200 # Goobstation - was 100 # Corvax-Goob-OreSmeltingRebalance
   - type: Extractable
     grindableSolutionName: silverore
   - type: SolutionContainerManager
@@ -286,7 +286,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      RawQuartz: 300 # Goobstation - was 100
+      RawQuartz: 200 # Goobstation - was 100 # Corvax-Goob-OreSmeltingRebalance
   - type: Extractable
     grindableSolutionName: quartzore
   - type: SolutionContainerManager
@@ -324,7 +324,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      RawUranium: 500 # Goobstation - was 100
+      RawUranium: 200 # Goobstation - was 100 # Corvax-Goob-OreSmeltingRebalance
   - type: PointLight
     radius: 1.2
     energy: 0.8
@@ -374,7 +374,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      RawBananium: 300 # Goobstation - was 100
+      RawBananium: 200 # Goobstation - was 100 # Corvax-Goob-OreSmeltingRebalance
   - type: PointLight
     radius: 1.2
     energy: 1
@@ -441,7 +441,7 @@
           Quantity: 0.1
   - type: PhysicalComposition
     materialComposition:
-      Coal: 300 # Goobstation - was 100
+      Coal: 200 # Goobstation - was 100 # Corvax-Goob-OreSmeltingRebalance
   - type: Item
     heldPrefix: coal
 
@@ -495,7 +495,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      RawSalt: 300 # Goobstation - was 100
+      RawSalt: 200 # Goobstation - was 100 # Corvax-Goob-OreSmeltingRebalance
   - type: Extractable
     grindableSolutionName: saltore
   - type: SolutionContainerManager

--- a/Resources/Prototypes/Recipes/Lathes/sheet.yml
+++ b/Resources/Prototypes/Recipes/Lathes/sheet.yml
@@ -37,16 +37,16 @@
   result: SheetSteel1
   completetime: 0
   materials:
-    RawIron: 20 # Goobstation - was 100
-    Coal: 10 # Goobstation - was 30
+    RawIron: 100 # Goobstation - was 100 # Corvax-Goob-OreSmeltingRebalance
+    Coal: 30 # Goobstation - was 30 # Corvax-Goob-OreSmeltingRebalance
 
 - type: latheRecipe
   id: SheetSteel30
   result: SheetSteel
   completetime: 2
   materials:
-    RawIron: 600 # Goobstation - was 3000
-    Coal: 300 # Goobstation - was 1000
+    RawIron: 3000 # Goobstation - was 3000 # Corvax-Goob-OreSmeltingRebalance
+    Coal: 1000 # Goobstation - was 1000 # Corvax-Goob-OreSmeltingRebalance
 
 - type: latheRecipe
   id: SheetGlass1


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Ko4ergaPunk <nikitako4erga3i5@gmail.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## Описание PR
<!-- Что вы изменили? -->
### Изменены значения для переплавки руд
- Сталь (0.07 руды за 1 лист -> 0.5 руды за 1 лист)
- Прочие руды (0.33 руды за 1 лист -> 0.5 руды за 1 лист)

Теперь значения как на Ваниле, но дешевле в два раза. Очищенный бриллиант без изменений.

## Почему / Баланс
<!-- Обсудите, как это повлияет на баланс игры или объясните, почему это было изменено. Укажите ссылки на соответствующие обсуждения или issue. -->
пиздец
